### PR TITLE
Update apm_wrapper.sh

### DIFF
--- a/apm/apm_wrapper.sh
+++ b/apm/apm_wrapper.sh
@@ -12,6 +12,8 @@ APM_PROP_FILE=${APM_AGENT_HOME}/config/AgentStartup.properties
 # then add them back in with the correct paths from APM_AGENT_HOME
 
 sed "/oracle.apmaas.common.pathTo/d" -i.orig ${APM_PROP_FILE}
+sed "/oracle.apmaas.agent.hostname/d" -i.orig ${APM_PROP_FILE}
+sed "/oracle.apmaas.agent.ignore.hostname/d" -i.orig ${APM_PROP_FILE}
 echo "oracle.apmaas.common.pathToCertificate = ${APM_AGENT_HOME}/config/emcs.cer" >> ${APM_PROP_FILE}
 echo "oracle.apmaas.common.pathToCredentials = ${APM_AGENT_HOME}/config/AgentHttpBasic.properties" >> ${APM_PROP_FILE}
 echo "oracle.apmaas.agent.ignore.hostname = true" >> ${APM_PROP_FILE}


### PR DESCRIPTION
We want the agent to get the host name from the runtime environment and not the build machine. This keeps the configuration fresh